### PR TITLE
Add Multiple Column Selection for SELECT Queries

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -37,9 +37,9 @@ impl Database {
         }
     }
 
-    pub fn select_all(&self, table_name: &str) {
+    pub fn select_all(&self, table_name: &str, selected_colums: Vec<String>) {
         if let Some(table) = self.tables.get(table_name) {
-            table.select_all();
+            table.select_all_with_columns(selected_colums);
         } else {
             println!("Error: Table '{}' does not exist.", table_name);
         }
@@ -47,21 +47,22 @@ impl Database {
 
     /// WHERE 句による検索：指定されたテーブルの、任意カラムの値が search_value と一致する行を表示する。
     /// 主キー検索は B+Tree による高速検索で行い、それ以外は全件走査してフィルタリングする。
-    pub fn select_where(&self, table_name: &str, column_name: &str, search_value: &str) {
-        if let Some(table) = self.get_table(table_name) {
-            let results = table.select_where(column_name, search_value);
-            if results.is_empty() {
-                println!("No matching row found for {} = '{}'.", column_name, search_value);
-            } else {
-                println!("Columns: {:?}", table.columns);
-                for row in results {
-                    println!("Row: {:?}", row);
-                }
-            }
-        } else {
-            println!("Error: Table '{}' does not exist.", table_name);
-        }
-    }
+    pub fn select_where(&self, table_name: &str, selected_columns: &Vec<String>, condition_column: &str, search_value: &str) {
+       if let Some(table) = self.get_table(table_name) {
+           let results = table.select_where(condition_column, search_value);
+           if results.is_empty() {
+               println!("No matching row found for {} = '{}'.", condition_column, search_value);
+           } else {
+               println!("Columns: {:?}", selected_columns);
+               for row in results {
+                   println!("Row: {:?}", row);
+               }
+           }
+       } else {
+           println!("Error: Table '{}' does not exist.", table_name);
+       }
+    } 
+    
 
     pub fn save_data(&self, path: &str) {
         let file = OpenOptions::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,13 +47,13 @@ fn main() {
             }
         } else if command_line.starts_with("SELECT") {
             if command_line.contains("WHERE") {
-                if let Some((table_name, column_name, search_value)) = parse_select_where(command_line) {
-                    db.select_where(&table_name, &column_name, &search_value);
+                if let Some((table_name, column_name, search_value, condition_value)) = parse_select_where(command_line) {
+                    db.select_where(&table_name, &column_name, &search_value, &condition_value);
                 } else {
                     println!("Error: Invalid SELECT WHERE syntax.");
                 }
-            } else if let Some(table_name) = parse_select_table(command_line) {
-                db.select_all(&table_name);
+            } else if let Some((table_name, columns)) = parse_select_table(command_line) {
+                db.select_all(&table_name, columns);
             } else {
                 println!("Error: Invalid SELECT syntax.");
             }

--- a/src/parser/select.rs
+++ b/src/parser/select.rs
@@ -1,31 +1,66 @@
 use crate::utils::trim_quotes;
 
-pub fn parse_select_table(command: &str) -> Option<String> {
-    let parts: Vec<&str> = command.split_whitespace().collect();
-    if parts.len() < 4 || parts[1] != "*" || parts[2].to_uppercase() != "FROM" {
+pub fn parse_select_table(command: &str) -> Option<(String, Vec<String>)> {
+    // コマンドから末尾のセミコロンを除去し、前後の空白をトリム
+    let command = command.trim_end_matches(';').trim();
+    // "SELECT " で始まっているか確認
+    if !command.to_uppercase().starts_with("SELECT ") {
         return None;
     }
-    Some(parts[3].trim_end_matches(';').to_string())
-}
-
-/// 例: "SELECT * FROM users WHERE age = '30';" → ("users", "age", "30")
-pub fn parse_select_where(command: &str) -> Option<(String, String, String)> {
-    let command = command.trim_end_matches(';').trim();
-    let parts: Vec<&str> = command.splitn(2, "WHERE").collect();
+    // "SELECT " を除去して残りを取得
+    let without_select = &command[7..]; // "SELECT "は7文字
+    // " FROM " で分割（前半がカラム指定、後半がテーブル名）
+    let parts: Vec<&str> = without_select.splitn(2, " FROM ").collect();
     if parts.len() != 2 {
         return None;
     }
-    let tokens: Vec<&str> = parts[0].trim().split_whitespace().collect();
-    if tokens.len() < 4 {
+    let columns_str = parts[0].trim();
+    let table_name = parts[1].trim().to_string();
+    // カラム指定が "*" の場合はそのまま、それ以外はカンマで分割して各カラム名をトリム
+    let columns: Vec<String> = if columns_str == "*" {
+        vec!["*".to_string()]
+    } else {
+        columns_str.split(',')
+            .map(|s| s.trim().to_string())
+            .collect()
+    };
+    Some((table_name, columns))
+}
+
+
+/// 例: "SELECT * FROM users WHERE age = '30';" → ("users", "*", "age", "30")
+pub fn parse_select_where(command: &str) -> Option<(String, Vec<String>, String, String)> {
+    // 末尾のセミコロンを除去しトリム
+    let command = command.trim_end_matches(';').trim();
+    // " WHERE " で分割（前半が SELECT 部、後半が条件部）
+    let parts: Vec<&str> = command.splitn(2, " WHERE ").collect();
+    if parts.len() != 2 {
         return None;
     }
-    let table_name = tokens[3].to_string();
-    let condition = parts[1].trim();
-    let cond_parts: Vec<&str> = condition.split('=').map(|s| s.trim()).collect();
+    // SELECT 部を解析
+    if !parts[0].to_uppercase().starts_with("SELECT ") {
+        return None;
+    }
+    let select_part = &parts[0][7..]; // "SELECT "を除去
+    let select_parts: Vec<&str> = select_part.splitn(2, " FROM ").collect();
+    if select_parts.len() != 2 {
+        return None;
+    }
+    let columns_str = select_parts[0].trim();
+    let table_name = select_parts[1].trim().to_string();
+    let columns: Vec<String> = if columns_str == "*" {
+        vec!["*".to_string()]
+    } else {
+        columns_str.split(',')
+            .map(|s| s.trim().to_string())
+            .collect()
+    };
+    // WHERE 部の解析（例: "age = '30'" や "id = 10"）
+    let cond_parts: Vec<&str> = parts[1].splitn(2, "=").map(|s| s.trim()).collect();
     if cond_parts.len() != 2 {
         return None;
     }
-    let column = cond_parts[0].to_string();
-    let value = trim_quotes(cond_parts[1]);
-    Some((table_name, column, value))
+    let condition_column = cond_parts[0].to_string();
+    let condition_value = trim_quotes(cond_parts[1]);
+    Some((table_name, columns, condition_column, condition_value))
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -55,11 +55,23 @@ impl Table {
     }
 
     /// 全件検索して結果を表示する
-    pub fn select_all(&self) {
-        println!("Columns: {:?}", self.columns);
+    pub fn select_all_with_columns(&self, selected_columns: Vec<String>) {
+        println!("Columns: {:?}", selected_columns);
         let rows = self.get_all_rows();
-        for row in rows {
-            println!("Row: {:?}", row);
+        // 表示するカラムが "*" の場合は全カラム表示
+        if selected_columns.len() == 1 && selected_columns[0] == "*" {
+            for row in rows {
+                println!("Row: {:?}", row);
+            }
+        } else {
+            // selected_columns に応じたカラムのインデックスを特定する
+            let indices: Vec<usize> = selected_columns.iter()
+                .filter_map(|col| self.columns.iter().position(|c| c == col))
+                .collect();
+            for row in rows {
+                let filtered: Vec<&String> = indices.iter().filter_map(|&i| row.get(i)).collect();
+                println!("Row: {:?}", filtered);
+            }
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new feature that enables users to specify one or more columns in SELECT queries instead of only using the "*" syntax. The main changes are as follows:

1. Parser Enhancements (parser/select.rs):
- The SELECT parser now extracts the column list from the query by removing the "SELECT " prefix and splitting the substring before " FROM " by commas.
- For queries without a WHERE clause, it returns a tuple of (table_name, Vec<String>). For queries with a WHERE clause, it returns (table_name, Vec<String>, condition_column, condition_value).
- These changes allow queries like "SELECT id, name FROM users;" to be correctly parsed.

2. Main Application Updates (main.rs):
- The SELECT command handling is updated to pattern-match the new 4-element tuple from the WHERE query parser and a 2-element tuple for non-WHERE queries.
- This ensures that queries with multiple column specifications are properly processed.

3. Database and Table Module Enhancements:
- A new method select_all_with_columns has been added to the Table module, which uses the provided column list to filter and display only the selected columns.
- The Database module's select_where method is also updated to accept and pass the selected columns to the Table method.